### PR TITLE
Exclude images from IPFS data saved in review table

### DIFF
--- a/logic/indexer_service.py
+++ b/logic/indexer_service.py
@@ -94,8 +94,12 @@ class DatabaseIndexer():
         Not sure if we would have updates on Review, sticking to classmethod
         naming covention for now.
         """
+        # Load IPFS data. Note: we filter out pictures since those should
+        # not get persisted in the database.
         review_data['ipfs_data'] = \
-            IPFSHelper().file_from_hash(review_data['ipfs_hash'])
+            IPFSHelper().file_from_hash(review_data['ipfs_hash'],
+                                        root_attr='data',
+                                        exclude_fields=['pictures'])
         review_obj = Review(**review_data)
         db.session.add(review_obj)
         db.session.commit()


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [X] Code contains relevant tests for the problem you are solving
- [X] Code has been formatted with `autopep8 --in-place --recursive --a --a .`
- [X] Ensure all new and existing tests pass
- [X] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)
- [X] Submit to the `develop` branch instead of `master`

### Description:

Filter out binary picture data from the IPFS data saved in the review database table.
This should fix issue #104 .