### PR TITLE
Change environment file defaults to work with origin-box

### DIFF
--- a/dev.env
+++ b/dev.env
@@ -1,4 +1,5 @@
 DEBUG=1
+
 # HOST is currently used for absolut urls for example on return urls from oath
 # BIND_HOST is the host that flask is binding to when running as it's only server
 # BIND_HOST is ignored when running under waitress-serve
@@ -6,8 +7,13 @@ HOST=localhost:5000
 BIND_HOST=0.0.0.0:5000
 HTTPS=0
 FLASK_SECRET_KEY=dev-secret-key
-DATABASE_URL=postgresql://localhost/bridge-server
-WEB3_PROVIDER_URI=http://localhost:8545
+
+DATABASE_URL=postgresql://docker:docker@localhost:5432/origin-bridge
+
+REDIS_URL=redis://127.0.0.1:6379/0
+
+RPC_SERVER=http://localhost:8545
+RPC_PROTOCOL=https
 
 # In dev, you don't need to set the PROJECTPATH, as settings.py
 # will set it to the current working directory. If running
@@ -24,11 +30,6 @@ SENDGRID_API_KEY=
 TWILIO_ACCOUNT_SID=
 TWILIO_AUTH_TOKEN=
 TWILIO_NUMBER=
-
-REDIS_URL=
-
-RPC_SERVER=
-RPC_PROTOCOL=
 
 IPFS_DOMAIN=
 IPFS_PORT=


### PR DESCRIPTION
Given that new developers are going to be almost certainly running the bridge server in the origin-box docker container, it makes sense for our config defaults to work out of the box there.

- [x] Removed no longer used WEB3_PROVIDER_URI config variable
- [x] Set DATABASE_URL, RPC_*, and REDIS_URL to match box defaults