### PR TITLE
Fix mistake with twilio verify API endpoint

### DIFF
--- a/logic/attestation_service.py
+++ b/logic/attestation_service.py
@@ -131,7 +131,7 @@ class VerificationService:
             'X-Authy-API-Key': settings.TWILIO_VERIFY_API_KEY
         }
 
-        url = 'https://api.authy.com/protected/json/phones/verification/status'
+        url = 'https://api.authy.com/protected/json/phones/verification/check'
         response = requests.get(url, params=params, headers=headers)
 
         try:

--- a/tests/services/test_attestation.py
+++ b/tests/services/test_attestation.py
@@ -111,7 +111,7 @@ def test_send_phone_verification_twilio_error():
 def test_verify_phone_valid_code():
     responses.add(
         responses.GET,
-        'https://api.authy.com/protected/json/phones/verification/status',
+        'https://api.authy.com/protected/json/phones/verification/check',
         json={
             'message': 'Verification code is correct.',
             'success': True
@@ -136,7 +136,7 @@ def test_verify_phone_valid_code():
 def test_verify_phone_expired_code():
     responses.add(
         responses.GET,
-        'https://api.authy.com/protected/json/phones/verification/status',
+        'https://api.authy.com/protected/json/phones/verification/check',
         json={'error_code': '60023'},   # No pending verification
         status=404
     )
@@ -159,7 +159,7 @@ def test_verify_phone_expired_code():
 def test_verify_phone_invalid_code():
     responses.add(
         responses.GET,
-        'https://api.authy.com/protected/json/phones/verification/status',
+        'https://api.authy.com/protected/json/phones/verification/check',
         json={'error_code': '60022'},   # No pending verification
         status=401
     )

--- a/tests/views/test_web.py
+++ b/tests/views/test_web.py
@@ -38,7 +38,7 @@ def test_verify_phone(client):
     with responses.RequestsMock() as rsps:
         rsps.add(
             responses.GET,
-            'https://api.authy.com/protected/json/phones/verification/status',
+            'https://api.authy.com/protected/json/phones/verification/check',
             json={
                 'message': 'Verification code is correct.',
                 'success': True


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [x] Code contains relevant tests for the problem you are solving
- [x] Code has been formatted with `autopep8 --in-place --recursive --a --a .`
- [x] Ensure all new and existing tests pass
- [x] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)
- [x] Submit to the `develop` branch instead of `master`

### Description:

Call to check verification code was going to the wrong endpoint (grabbing the status instead of checking it) resulting in everything being considered a valid code. Sorry, not sure how I did that!