### PR TITLE
Update pagination configuration

### DIFF
--- a/app/app_config.py
+++ b/app/app_config.py
@@ -38,13 +38,16 @@ def init_api(app):
     # default. Allowed HTTP methods can be specified as well.
     manager.create_api(db_models.Listing, methods=['GET'],
                        primary_key='contract_address',
-                       results_per_page=10,)
+                       results_per_page=10,
+                       max_results_per_page=100)
     manager.create_api(db_models.Purchase, methods=['GET'],
                        primary_key='contract_address',
-                       results_per_page=10,)
+                       results_per_page=10,
+                       max_results_per_page=100)
     manager.create_api(db_models.Review, methods=['GET'],
                        primary_key='contract_address',
-                       results_per_page=10,)
+                       results_per_page=10,
+                       max_results_per_page=100)
 
 
 # App initialization only appropriate for dev/production but not tests.


### PR DESCRIPTION
### Checklist:
- [x] Ensure all new and existing tests pass
- [x] Submit to the `develop` branch instead of `master`

### Description:
- Listing, Purchase and Review resources when queried by default return 10 items. With maximum number of parameters per page allowed set to 100. 

### Query parameter to use: 
- `page` indicates the pagination page number
- `results_per_page` number of results per page. Defaults to 10, can be between 1 - 100. 

### Fixes following issues: 
- https://github.com/OriginProtocol/origin-bridge/issues/99
- https://github.com/OriginProtocol/origin-bridge/issues/100
- https://github.com/OriginProtocol/origin-bridge/issues/101